### PR TITLE
media: add GetMediaInfo method

### DIFF
--- a/encodingcom/media.go
+++ b/encodingcom/media.go
@@ -79,3 +79,31 @@ func (c *Client) ListMedia() (*ListMediaResponse, error) {
 	}
 	return result["response"], nil
 }
+
+// MediaInfo is the result of the GetMediaInfo method.
+//
+// See http://goo.gl/OTX0Ua for more details.
+type MediaInfo struct {
+	Duration           float64 `json:"duration,string"`
+	Bitrate            string  `json:"bitrate"`
+	VideoCodec         string  `json:"video_codec"`
+	VideoBitrate       string  `json:"video_bitrate"`
+	Framerate          string  `json:"frame_rate"`
+	Size               string  `json:"size"`
+	PixelAspectRatio   string  `json:"pixel_aspect_ratio"`
+	DisplayAspectRatio string  `json:"display_aspect_ratio"`
+	AudioCodec         string  `json:"audio_codec"`
+	AudioBitrate       string  `json:"audio_bitrate"`
+	AudioSampleRate    uint    `json:"audio_sample_rate,string"`
+	AudioChannels      string  `json:"audio_channels"`
+}
+
+// GetMediaInfo returns video parameters of the specified media when available.
+func (c *Client) GetMediaInfo(mediaID string) (*MediaInfo, error) {
+	var result map[string]*MediaInfo
+	err := c.do(&request{Action: "GetMediaInfo", MediaID: mediaID}, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result["response"], nil
+}

--- a/encodingcom/media_test.go
+++ b/encodingcom/media_test.go
@@ -70,3 +70,47 @@ func (s *S) TestListMedia(c *check.C) {
 	req := <-requests
 	c.Assert(req.query["action"], check.Equals, "GetMediaList")
 }
+
+func (s *S) TestGetMediaInfo(c *check.C) {
+	server, requests := s.startServer(`
+{
+	"response": {
+		"bitrate": "1807k",
+		"duration": "6464.83",
+		"audio_bitrate": "128k",
+		"video_codec": "mpeg4",
+		"video_bitrate": "1679k",
+		"frame_rate": "23.98",
+		"size": "640x352",
+		"pixel_aspect_ratio": "1:1",
+		"display_aspect_ratio": "20:11",
+		"audio_codec": "ac3",
+		"audio_sample_rate": "48000",
+		"audio_channels": "2"
+	}
+}`, http.StatusOK)
+	defer server.Close()
+
+	client := Client{Endpoint: server.URL, UserID: "myuser", UserKey: "123"}
+	mediaInfo, err := client.GetMediaInfo("m-123")
+	c.Assert(err, check.IsNil)
+
+	c.Assert(mediaInfo, check.DeepEquals, &MediaInfo{
+		Bitrate:            "1807k",
+		Duration:           6464.83,
+		VideoCodec:         "mpeg4",
+		VideoBitrate:       "1679k",
+		Framerate:          "23.98",
+		Size:               "640x352",
+		PixelAspectRatio:   "1:1",
+		DisplayAspectRatio: "20:11",
+		AudioCodec:         "ac3",
+		AudioSampleRate:    uint(48000),
+		AudioChannels:      "2",
+		AudioBitrate:       "128k",
+	})
+
+	req := <-requests
+	c.Assert(req.query["action"], check.Equals, "GetMediaInfo")
+	c.Assert(req.query["mediaid"], check.Equals, "m-123")
+}


### PR DESCRIPTION
This method will unmarshal the media info JSON into the MediaInfo struct
and return it to the calling code.

I believe we can start exploring an integration test suite to ensure
that all types are compatible with everything.

Closes #7.