### PR TITLE
encodingcom: implement GetStatus

### DIFF
--- a/encodingcom/client.go
+++ b/encodingcom/client.go
@@ -128,6 +128,7 @@ type request struct {
 	NotifyURL               string       `json:"notify,omitempty"`
 	NotifyEncodingErrorsURL string       `json:"notify_encoding_errors,omitempty"`
 	NotifyUploadURL         string       `json:"notify_upload,omitempty"`
+	Extended                YesNoBoolean `json:"extended,omitempty"`
 	Format                  *Format      `json:"format,omitempty"`
 }
 

--- a/encodingcom/status.go
+++ b/encodingcom/status.go
@@ -1,0 +1,147 @@
+package encodingcom
+
+import (
+	"errors"
+	"strings"
+	"time"
+)
+
+// StatusResponse is the result of the GetStatus method.
+//
+// See http://goo.gl/NDsN8h for more details.
+type StatusResponse struct {
+	MediaID             string
+	UserID              string
+	SourceFile          string
+	MediaStatus         string
+	PreviousMediaStatus string
+	NotifyURL           string
+	CreateDate          time.Time
+	StartDate           time.Time
+	FinishDate          time.Time
+	DownloadDate        time.Time
+	UploadDate          time.Time
+	TimeLeft            string
+	Progress            float64
+	TimeLeftCurrentJob  string
+	ProgressCurrentJob  float64
+	Formats             []FormatStatus
+}
+
+// FormatStatus is the status of each formatting input for a given MediaID.
+//
+// It is part of the StatusResponse type.
+type FormatStatus struct {
+	ID            string
+	Status        string
+	CreateDate    time.Time
+	StartDate     time.Time
+	FinishDate    time.Time
+	S3Destination string
+	CFDestination string
+	Destinations  []DestinationStatus
+}
+
+// DestinationStatus represents the status of a given destination.
+type DestinationStatus struct {
+	Name   string
+	Status string
+}
+
+// GetStatus returns the status of the given media ids, it returns an slice of
+// StatusResponse, the size of the result slice matches the size of input
+// slice.
+func (c *Client) GetStatus(mediaIDs []string) ([]StatusResponse, error) {
+	switch len(mediaIDs) {
+	case 0:
+		return nil, errors.New("please provide at least one media id")
+	}
+	var m map[string]map[string][]statusJSON
+	err := c.do(&request{
+		Action:   "GetStatus",
+		MediaID:  strings.Join(mediaIDs, ","),
+		Extended: true,
+	}, &m)
+	if err != nil {
+		return nil, err
+	}
+	apiStatus := m["response"]["job"]
+	statusResponse := make([]StatusResponse, len(apiStatus))
+	for i, status := range apiStatus {
+		statusResponse[i] = status.toStruct()
+	}
+	return statusResponse, nil
+}
+
+type statusJSON struct {
+	MediaID             string             `json:"id"`
+	UserID              string             `json:"userid"`
+	SourceFile          string             `json:"sourcefile"`
+	MediaStatus         string             `json:"status"`
+	PreviousMediaStatus string             `json:"prevstatus"`
+	NotifyURL           string             `json:"notifyurl"`
+	CreateDate          MediaDateTime      `json:"created"`
+	StartDate           MediaDateTime      `json:"started"`
+	FinishDate          MediaDateTime      `json:"finished"`
+	DownloadDate        MediaDateTime      `json:"downloaded"`
+	UploadDate          MediaDateTime      `json:"uploaded"`
+	TimeLeft            string             `json:"time_left"`
+	Progress            float64            `json:"progress,string"`
+	TimeLeftCurrentJob  string             `json:"time_left_current"`
+	ProgressCurrentJob  float64            `json:"progress_current,string"`
+	Formats             []formatStatusJSON `json:"format"`
+}
+
+func (s *statusJSON) toStruct() StatusResponse {
+	resp := StatusResponse{
+		MediaID:             s.MediaID,
+		UserID:              s.UserID,
+		SourceFile:          s.SourceFile,
+		MediaStatus:         s.MediaStatus,
+		PreviousMediaStatus: s.PreviousMediaStatus,
+		NotifyURL:           s.NotifyURL,
+		CreateDate:          s.CreateDate.Time,
+		StartDate:           s.StartDate.Time,
+		FinishDate:          s.FinishDate.Time,
+		DownloadDate:        s.DownloadDate.Time,
+		UploadDate:          s.UploadDate.Time,
+		TimeLeft:            s.TimeLeft,
+		Progress:            s.Progress,
+		TimeLeftCurrentJob:  s.TimeLeftCurrentJob,
+		ProgressCurrentJob:  s.ProgressCurrentJob,
+		Formats:             make([]FormatStatus, len(s.Formats)),
+	}
+	for i, formatStatus := range s.Formats {
+		format := FormatStatus{
+			ID:            formatStatus.ID,
+			Status:        formatStatus.Status,
+			CreateDate:    formatStatus.CreateDate.Time,
+			StartDate:     formatStatus.StartDate.Time,
+			FinishDate:    formatStatus.FinishDate.Time,
+			S3Destination: formatStatus.S3Destination,
+			CFDestination: formatStatus.CFDestination,
+			Destinations:  make([]DestinationStatus, len(formatStatus.Destinations)),
+		}
+		for i, dest := range formatStatus.Destinations {
+			destStatus := DestinationStatus{Name: dest}
+			if i < len(formatStatus.DestinationsStatus) {
+				destStatus.Status = formatStatus.DestinationsStatus[i]
+			}
+			format.Destinations[i] = destStatus
+		}
+		resp.Formats[i] = format
+	}
+	return resp
+}
+
+type formatStatusJSON struct {
+	ID                 string        `json:"id"`
+	Status             string        `json:"status"`
+	CreateDate         MediaDateTime `json:"created"`
+	StartDate          MediaDateTime `json:"started"`
+	FinishDate         MediaDateTime `json:"finished"`
+	S3Destination      string        `json:"s3_destination"`
+	CFDestination      string        `json:"cf_destination"`
+	Destinations       []string      `json:"destination"`
+	DestinationsStatus []string      `json:"destination_status"`
+}

--- a/encodingcom/status_test.go
+++ b/encodingcom/status_test.go
@@ -1,0 +1,234 @@
+package encodingcom
+
+import (
+	"time"
+
+	"gopkg.in/check.v1"
+)
+
+func (s *S) TestGetStatusSingle(c *check.C) {
+	server, requests := s.startServer(`
+{
+	"response": {
+		"job": [
+			{
+				"id": "abc123",
+				"userid": "myuser",
+				"sourcefile": "http://some.video/file.mp4",
+				"status": "Finished",
+				"notifyurl": "http://ping.me/please",
+				"created": "2015-12-31 20:45:30",
+				"started": "2015-12-31 20:45:34",
+				"finished": "2015-12-31 21:00:03",
+				"prevstatus": "Saving",
+				"downloaded": "2015-12-31 20:45:32",
+				"uploaded": "2015-12-31 20:59:54",
+				"time_left": "0",
+				"progress": "100",
+				"time_left_current": "0",
+				"progress_current": "100.0",
+				"format": [
+					{
+						"id": "f123",
+						"status": "Finished",
+						"created": "2015-12-31 20:45:30",
+						"started": "2015-12-31 20:45:34",
+						"finished": "2015-12-31 21:00:03",
+						"s3_destination": "https://s3.amazonaws.com/not-really/valid.mp4",
+						"cf_destination": "https://blablabla.cloudfront.net/not-valid.mp4",
+						"destination": [
+							"s3://mynicebucket"
+						],
+						"destination_status": [
+							"Saved"
+						]
+					}
+				]
+			}
+		]
+	}
+}`)
+	defer server.Close()
+
+	client := Client{Endpoint: server.URL, UserID: "myuser", UserKey: "123"}
+	status, err := client.GetStatus([]string{"abc123"})
+	c.Assert(err, check.IsNil)
+
+	expectedCreateDate, _ := time.Parse(dateTimeLayout, "2015-12-31 20:45:30")
+	expectedStartDate, _ := time.Parse(dateTimeLayout, "2015-12-31 20:45:34")
+	expectedFinishDate, _ := time.Parse(dateTimeLayout, "2015-12-31 21:00:03")
+	expectedDownloadDate, _ := time.Parse(dateTimeLayout, "2015-12-31 20:45:32")
+	expectedUploadDate, _ := time.Parse(dateTimeLayout, "2015-12-31 20:59:54")
+	expected := []StatusResponse{
+		{
+			MediaID:             "abc123",
+			UserID:              "myuser",
+			SourceFile:          "http://some.video/file.mp4",
+			MediaStatus:         "Finished",
+			PreviousMediaStatus: "Saving",
+			NotifyURL:           "http://ping.me/please",
+			CreateDate:          expectedCreateDate,
+			StartDate:           expectedStartDate,
+			FinishDate:          expectedFinishDate,
+			DownloadDate:        expectedDownloadDate,
+			UploadDate:          expectedUploadDate,
+			TimeLeft:            "0",
+			Progress:            100.0,
+			TimeLeftCurrentJob:  "0",
+			ProgressCurrentJob:  100.0,
+			Formats: []FormatStatus{
+				{
+					ID:            "f123",
+					Status:        "Finished",
+					CreateDate:    expectedCreateDate,
+					StartDate:     expectedStartDate,
+					FinishDate:    expectedFinishDate,
+					S3Destination: "https://s3.amazonaws.com/not-really/valid.mp4",
+					CFDestination: "https://blablabla.cloudfront.net/not-valid.mp4",
+					Destinations:  []DestinationStatus{{Name: "s3://mynicebucket", Status: "Saved"}},
+				},
+			},
+		},
+	}
+	c.Assert(status, check.DeepEquals, expected)
+
+	req := <-requests
+	c.Assert(req.query["action"], check.Equals, "GetStatus")
+	c.Assert(req.query["mediaid"], check.Equals, "abc123")
+	c.Assert(req.query["extended"], check.Equals, "yes")
+}
+
+func (s *S) TestGetStatusMultiple(c *check.C) {
+	server, requests := s.startServer(`
+{
+	"response": {
+		"job": [
+			{
+				"id": "abc123",
+				"userid": "myuser",
+				"sourcefile": "http://some.video/file.mp4",
+				"status": "Finished",
+				"notifyurl": "http://ping.me/please",
+				"created": "2015-12-31 20:45:30",
+				"started": "2015-12-31 20:45:34",
+				"finished": "2015-12-31 21:00:03",
+				"prevstatus": "Saving",
+				"downloaded": "2015-12-31 20:45:32",
+				"uploaded": "2015-12-31 20:59:54",
+				"time_left": "0",
+				"progress": "100",
+				"time_left_current": "0",
+				"progress_current": "100.0",
+				"format": [
+					{
+						"id": "f123",
+						"status": "Finished",
+						"created": "2015-12-31 20:45:30",
+						"started": "2015-12-31 20:45:34",
+						"finished": "2015-12-31 21:00:03",
+						"s3_destination": "https://s3.amazonaws.com/not-really/valid.mp4",
+						"cf_destination": "https://blablabla.cloudfront.net/not-valid.mp4",
+						"destination": [
+							"s3://mynicebucket"
+						],
+						"destination_status": [
+							"Saved"
+						]
+					}
+				]
+			},
+			{
+				"id": "abc124",
+				"userid": "myuser",
+				"sourcefile": "http://some.video/file.mp4",
+				"status": "Finished",
+				"notifyurl": "http://ping.me/please",
+				"created": "2015-12-31 20:45:30",
+				"started": "2015-12-31 20:45:34",
+				"finished": "2015-12-31 21:00:03",
+				"prevstatus": "Saving",
+				"downloaded": "2015-12-31 20:45:32",
+				"uploaded": "2015-12-31 20:59:54",
+				"time_left": "0",
+				"progress": "100",
+				"time_left_current": "0",
+				"progress_current": "100.0",
+				"format": [
+					{
+						"id": "f123",
+						"status": "Finished",
+						"created": "2015-12-31 20:45:30",
+						"started": "2015-12-31 20:45:34",
+						"finished": "2015-12-31 21:00:03",
+						"s3_destination": "https://s3.amazonaws.com/not-really/valid.mp4",
+						"cf_destination": "https://blablabla.cloudfront.net/not-valid.mp4",
+						"destination": [
+							"s3://mynicebucket"
+						],
+						"destination_status": [
+							"Saved"
+						]
+					}
+				]
+			}
+		]
+	}
+}`)
+	defer server.Close()
+
+	client := Client{Endpoint: server.URL, UserID: "myuser", UserKey: "123"}
+	status, err := client.GetStatus([]string{"abc123", "abc124"})
+	c.Assert(err, check.IsNil)
+
+	expectedCreateDate, _ := time.Parse(dateTimeLayout, "2015-12-31 20:45:30")
+	expectedStartDate, _ := time.Parse(dateTimeLayout, "2015-12-31 20:45:34")
+	expectedFinishDate, _ := time.Parse(dateTimeLayout, "2015-12-31 21:00:03")
+	expectedDownloadDate, _ := time.Parse(dateTimeLayout, "2015-12-31 20:45:32")
+	expectedUploadDate, _ := time.Parse(dateTimeLayout, "2015-12-31 20:59:54")
+	status1 := StatusResponse{
+		MediaID:             "abc123",
+		UserID:              "myuser",
+		SourceFile:          "http://some.video/file.mp4",
+		MediaStatus:         "Finished",
+		PreviousMediaStatus: "Saving",
+		NotifyURL:           "http://ping.me/please",
+		CreateDate:          expectedCreateDate,
+		StartDate:           expectedStartDate,
+		FinishDate:          expectedFinishDate,
+		DownloadDate:        expectedDownloadDate,
+		UploadDate:          expectedUploadDate,
+		TimeLeft:            "0",
+		Progress:            100.0,
+		TimeLeftCurrentJob:  "0",
+		ProgressCurrentJob:  100.0,
+		Formats: []FormatStatus{
+			{
+				ID:            "f123",
+				Status:        "Finished",
+				CreateDate:    expectedCreateDate,
+				StartDate:     expectedStartDate,
+				FinishDate:    expectedFinishDate,
+				S3Destination: "https://s3.amazonaws.com/not-really/valid.mp4",
+				CFDestination: "https://blablabla.cloudfront.net/not-valid.mp4",
+				Destinations:  []DestinationStatus{{Name: "s3://mynicebucket", Status: "Saved"}},
+			},
+		},
+	}
+	status2 := status1
+	status2.MediaID = "abc124"
+	expected := []StatusResponse{status1, status2}
+	c.Assert(status, check.DeepEquals, expected)
+
+	req := <-requests
+	c.Assert(req.query["action"], check.Equals, "GetStatus")
+	c.Assert(req.query["mediaid"], check.Equals, "abc123,abc124")
+	c.Assert(req.query["extended"], check.Equals, "yes")
+}
+
+func (s *S) TestGetStatusNoMedia(c *check.C) {
+	var client Client
+	status, err := client.GetStatus(nil)
+	c.Assert(err, check.NotNil)
+	c.Assert(err.Error(), check.Equals, "please provide at least one media id")
+	c.Assert(status, check.HasLen, 0)
+}


### PR DESCRIPTION
This method will collect the current status of media being transcoded.
The whole code might seem as a hack, but I wanted to workaround the way
that Encoding.com reports the status of each destination, so I decided
to create this DestinationStatus struct, and in order to do that I
needed to replicate part of some structs, but we have tests for those
duplications! haha

Maybe we could take a simpler approach and just use two slices to
represent destinations and their status, but I think that it's a fair
trade-off to have this kind of ugly code hidden in unexported types and
do some make-up on before returning them to the caller code.

Closes #1.