### PR TITLE
Elementalconductor: set XMLName on Preset structure

### DIFF
--- a/elementalconductor/presets.go
+++ b/elementalconductor/presets.go
@@ -1,5 +1,9 @@
 package elementalconductor
 
+import (
+	"encoding/xml"
+)
+
 // GetPresets returns a list of presets
 func (c *Client) GetPresets() (*PresetList, error) {
 	var result *PresetList
@@ -22,13 +26,14 @@ func (c *Client) GetPreset(presetID string) (*Preset, error) {
 }
 
 // CreatePreset creates a new preset
-func (c *Client) CreatePreset(p *Preset) (*Preset, error) {
-	err := c.do("POST", "/presets/", p, nil)
+func (c *Client) CreatePreset(preset *Preset) (*Preset, error) {
+	var result *Preset
+	err := c.do("POST", "/presets", preset, &result)
 	if err != nil {
 		return nil, err
 	}
 
-	return p, nil
+	return result, nil
 }
 
 // DeletePreset removes a preset based on its presetID
@@ -50,21 +55,22 @@ type PresetList struct {
 
 // Preset represents a preset
 type Preset struct {
-	Name          string `xml:"name"`
-	Href          string `xml:"href,attr,omitempty"`
-	Permalink     string `xml:"permalink,omitempty"`
-	Description   string `xml:"description,omitempty"`
-	Container     string `xml:"container,omitempty"`
-	Width         string `xml:"video_description>width,omitempty"`
-	Height        string `xml:"video_description>height,omitempty"`
-	VideoCodec    string `xml:"video_description>codec,omitempty"`
-	VideoBitrate  string `xml:"video_description>h264_settings>bitrate,omitempty"`
-	GopSize       string `xml:"video_description>h264_settings>gop_size,omitempty"`
-	GopMode       string `xml:"video_description>h264_settings>gop_mode,omitempty"`
-	Profile       string `xml:"video_description>h264_settings>profile,omitempty"`
-	ProfileLevel  string `xml:"video_description>h264_settings>level,omitempty"`
-	RateControl   string `xml:"video_description>h264_settings>rate_control_mode,omitempty"`
-	InterlaceMode string `xml:"video_description>h264_settings>interlace_mode"`
-	AudioCodec    string `xml:"audio_description>codec,omitempty"`
-	AudioBitrate  string `xml:"audio_description>aac_settings>bitrate"`
+	XMLName       xml.Name `xml:"preset"`
+	Name          string   `xml:"name"`
+	Href          string   `xml:"href,attr,omitempty"`
+	Permalink     string   `xml:"permalink,omitempty"`
+	Description   string   `xml:"description,omitempty"`
+	Container     string   `xml:"container,omitempty"`
+	Width         string   `xml:"video_description>width,omitempty"`
+	Height        string   `xml:"video_description>height,omitempty"`
+	VideoCodec    string   `xml:"video_description>codec,omitempty"`
+	VideoBitrate  string   `xml:"video_description>h264_settings>bitrate,omitempty"`
+	GopSize       string   `xml:"video_description>h264_settings>gop_size,omitempty"`
+	GopMode       string   `xml:"video_description>h264_settings>gop_mode,omitempty"`
+	Profile       string   `xml:"video_description>h264_settings>profile,omitempty"`
+	ProfileLevel  string   `xml:"video_description>h264_settings>level,omitempty"`
+	RateControl   string   `xml:"video_description>h264_settings>rate_control_mode,omitempty"`
+	InterlaceMode string   `xml:"video_description>h264_settings>interlace_mode,omitempty"`
+	AudioCodec    string   `xml:"audio_description>codec,omitempty"`
+	AudioBitrate  string   `xml:"audio_description>aac_settings>bitrate,omitempty"`
 }

--- a/elementalconductor/presets_test.go
+++ b/elementalconductor/presets_test.go
@@ -1,6 +1,7 @@
 package elementalconductor
 
 import (
+	"encoding/xml"
 	"net/http"
 
 	"gopkg.in/check.v1"
@@ -25,6 +26,7 @@ func (s *S) TestGetPresets(c *check.C) {
 </preset_list>`
 
 	expectedPreset1 := Preset{
+		XMLName:     xml.Name{Local: "preset"},
 		Name:        "iPhone",
 		Href:        "/presets/1",
 		Permalink:   "iphone",
@@ -32,6 +34,7 @@ func (s *S) TestGetPresets(c *check.C) {
 	}
 
 	expectedPreset2 := Preset{
+		XMLName:     xml.Name{Local: "preset"},
 		Name:        "iPhone_ADAPT_HIGH",
 		Href:        "/presets/2",
 		Permalink:   "iphone_adapt_high",
@@ -163,6 +166,7 @@ func (s *S) TestGetPreset(c *check.C) {
 </preset>`
 
 	expectedPreset := Preset{
+		XMLName:       xml.Name{Local: "preset"},
 		Name:          "iPhone",
 		Href:          "/presets/1",
 		Permalink:     "iphone",
@@ -312,6 +316,7 @@ func (s *S) TestGetPresetForHls(c *check.C) {
 </preset>`
 
 	expectedPreset := Preset{
+		XMLName:       xml.Name{Local: "preset"},
 		Name:          "nyt_hls_720p_high_uhd",
 		Href:          "/presets/149",
 		Permalink:     "nyt_hls_720p_high_uhd",
@@ -339,16 +344,115 @@ func (s *S) TestGetPresetForHls(c *check.C) {
 }
 
 func (s *S) TestCreatePreset(c *check.C) {
-	server, _ := s.startServer(http.StatusOK, "")
+	createPresetResponseXML := `<?xml version="1.0" encoding="UTF-8"?>
+<preset product="Elemental Conductor File + Audio Normalization Package + Audio Package" version="2.7.2vd.32545">
+  <name>TestPresetName</name>
+  <permalink></permalink>
+  <description>Preset test here</description>
+  <container>mp4</container>
+  <mp4_settings>
+    <id>163</id>
+    <include_cslg>false</include_cslg>
+    <mp4_major_brand nil="true"/>
+    <progressive_downloading>false</progressive_downloading>
+  </mp4_settings>
+  <log_edit_points>false</log_edit_points>
+  <video_description>
+    <afd_signaling>None</afd_signaling>
+    <anti_alias>true</anti_alias>
+    <drop_frame_timecode>true</drop_frame_timecode>
+    <encoder_type nil="true"/>
+    <fixed_afd nil="true"/>
+    <force_cpu_encode>false</force_cpu_encode>
+    <height>720</height>
+    <id>602</id>
+    <insert_color_metadata>false</insert_color_metadata>
+    <respond_to_afd>None</respond_to_afd>
+    <sharpness>50</sharpness>
+    <stretch_to_output>false</stretch_to_output>
+    <timecode_passthrough>false</timecode_passthrough>
+    <vbi_passthrough>false</vbi_passthrough>
+    <width nil="true"/>
+    <h264_settings>
+      <adaptive_quantization>medium</adaptive_quantization>
+      <bitrate>3800000</bitrate>
+      <buf_fill_pct nil="true"/>
+      <buf_size nil="true"/>
+      <cabac>true</cabac>
+      <flicker_reduction>off</flicker_reduction>
+      <force_field_pictures>false</force_field_pictures>
+      <framerate_denominator nil="true"/>
+      <framerate_follow_source>true</framerate_follow_source>
+      <framerate_numerator nil="true"/>
+      <gop_b_reference>false</gop_b_reference>
+      <gop_closed_cadence>1</gop_closed_cadence>
+      <gop_markers>false</gop_markers>
+      <gop_num_b_frames>2</gop_num_b_frames>
+      <gop_size>90</gop_size>
+      <id>540</id>
+      <interpolate_frc>false</interpolate_frc>
+      <look_ahead_rate_control>medium</look_ahead_rate_control>
+      <max_bitrate nil="true"/>
+      <max_qp nil="true"/>
+      <min_i_interval>0</min_i_interval>
+      <min_qp nil="true"/>
+      <num_ref_frames>1</num_ref_frames>
+      <par_denominator nil="true"/>
+      <par_follow_source>true</par_follow_source>
+      <par_numerator nil="true"/>
+      <passes>1</passes>
+      <qp nil="true"/>
+      <qp_step nil="true"/>
+      <repeat_pps>false</repeat_pps>
+      <scd>true</scd>
+      <sei_timecode>false</sei_timecode>
+      <slices>1</slices>
+      <slow_pal>false</slow_pal>
+      <softness nil="true"/>
+      <svq>0</svq>
+      <telecine>None</telecine>
+      <transition_detection>false</transition_detection>
+      <level>3.1</level>
+      <profile>Main</profile>
+      <rate_control_mode>VBR</rate_control_mode>
+      <gop_mode>fixed</gop_mode>
+      <interlace_mode>progressive</interlace_mode>
+    </h264_settings>
+    <gpu/>
+    <selected_gpu nil="true"/>
+    <codec>h.264</codec>
+  </video_description>
+  <audio_description>
+    <audio_type>0</audio_type>
+    <follow_input_audio_type>false</follow_input_audio_type>
+    <follow_input_language_code>false</follow_input_language_code>
+    <id>617</id>
+    <language_code nil="true"/>
+    <order>1</order>
+    <stream_name nil="true"/>
+    <aac_settings>
+      <bitrate>64000</bitrate>
+      <coding_mode>2_0</coding_mode>
+      <id>536</id>
+      <latm_loas>false</latm_loas>
+      <mpeg2>false</mpeg2>
+      <sample_rate>48000</sample_rate>
+      <profile>LC</profile>
+      <rate_control_mode>CBR</rate_control_mode>
+    </aac_settings>
+    <codec>aac</codec>
+  </audio_description>
+</preset>`
+	server, _ := s.startServer(http.StatusOK, createPresetResponseXML)
 	defer server.Close()
 
 	client := NewClient(server.URL, "myuser", "secret-key", 45, "aws-access-key", "aws-secret-key", "destination")
 
 	preset := Preset{
-		Name:          "nyt_hls_720p_high_uhd",
-		Href:          "/presets/149",
-		Permalink:     "nyt_hls_720p_high_uhd",
-		Container:     "m3u8",
+		XMLName:       xml.Name{Local: "preset"},
+		Name:          "TestPresetName",
+		Description:   "Preset test here",
+		Container:     "mp4",
 		VideoCodec:    "h.264",
 		AudioCodec:    "aac",
 		Height:        "720",


### PR DESCRIPTION
This is a bugfix when creating a preset on Elemental
Conductor API. We were sending the preset XML with
`<Preset>` instead of `<preset>` (with P capitalized)
because of the lack of XMLName field on the Preset
structure.

This commit also fixes the return type of `createPreset()`
call. Now we return the preset created in conformity with
`createJob()`.