### PR TITLE
Elemental: Not all group settings are always set

### DIFF
--- a/elementalconductor/job.go
+++ b/elementalconductor/job.go
@@ -154,22 +154,22 @@ type Location struct {
 
 // OutputGroup is a list of the indended outputs for the job
 type OutputGroup struct {
-	Order                  int                    `xml:"order,omitempty"`
-	FileGroupSettings      FileGroupSettings      `xml:"file_group_settings,omitempty"`
-	AppleLiveGroupSettings AppleLiveGroupSettings `xml:"apple_live_group_settings,omitempty"`
-	Type                   OutputGroupType        `xml:"type,omitempty"`
-	Output                 []Output               `xml:"output,omitempty"`
+	Order                  int                     `xml:"order,omitempty"`
+	FileGroupSettings      *FileGroupSettings      `xml:"file_group_settings,omitempty"`
+	AppleLiveGroupSettings *AppleLiveGroupSettings `xml:"apple_live_group_settings,omitempty"`
+	Type                   OutputGroupType         `xml:"type,omitempty"`
+	Output                 []Output                `xml:"output,omitempty"`
 }
 
 // FileGroupSettings define where the file job output should go
 type FileGroupSettings struct {
-	Destination Location `xml:"destination,omitempty"`
+	Destination *Location `xml:"destination,omitempty"`
 }
 
 // AppleLiveGroupSettings define where the HLS job output should go
 type AppleLiveGroupSettings struct {
-	Destination     Location `xml:"destination,omitempty"`
-	SegmentDuration uint     `xml:"segment_length,omitempty"`
+	Destination     *Location `xml:"destination,omitempty"`
+	SegmentDuration uint      `xml:"segment_length,omitempty"`
 }
 
 // Output defines the different processing stream assemblies

--- a/elementalconductor/job_test.go
+++ b/elementalconductor/job_test.go
@@ -98,15 +98,15 @@ func (s *S) TestCreateJob(c *check.C) {
 		Priority: 50,
 		OutputGroup: OutputGroup{
 			Order: 1,
-			FileGroupSettings: FileGroupSettings{
-				Destination: Location{
+			FileGroupSettings: &FileGroupSettings{
+				Destination: &Location{
 					URI:      "http://destination/video.mp4",
 					Username: "user",
 					Password: "pass123",
 				},
 			},
-			AppleLiveGroupSettings: AppleLiveGroupSettings{
-				Destination: Location{
+			AppleLiveGroupSettings: &AppleLiveGroupSettings{
+				Destination: &Location{
 					URI:      "http://destination/video.mp4",
 					Username: "user",
 					Password: "pass123",
@@ -186,8 +186,8 @@ func (s *S) TestGetJob(c *check.C) {
 		Priority: 50,
 		OutputGroup: OutputGroup{
 			Order: 1,
-			FileGroupSettings: FileGroupSettings{
-				Destination: Location{
+			FileGroupSettings: &FileGroupSettings{
+				Destination: &Location{
 					URI:      "http://destination/video.mp4",
 					Username: "user",
 					Password: "pass123",


### PR DESCRIPTION
In Elemental jobs, not all group settings are always set: either FileGroupSettings is set, or AppleLiveGroupSettings is set, but never both.

They need to be a nil pointer by default, otherwise they show up in the XML output when the job struct is marshaled and this was causing HLS jobs to fail. The omitempty on the xml tag does not prevent that, as described in the xml.Marshal documentation (http://golang.org/pkg/encoding/xml/#Marshal):

> The empty values are false, 0, any nil pointer or interface value, and any array, slice, map, or string of length zero.