### PR TITLE
Set Elemental multiple output groups and export client interface

### DIFF
--- a/elementalconductor/client.go
+++ b/elementalconductor/client.go
@@ -29,6 +29,20 @@ type Client struct {
 	Destination     string
 }
 
+// ClientInterface describes the behavior the client API provides.
+type ClientInterface interface {
+	GetPreset(presetID string) (*Preset, error)
+	CreatePreset(preset *Preset) (*Preset, error)
+	DeletePreset(presetID string) error
+	CreateJob(job *Job) (*Job, error)
+	GetJob(jobID string) (*Job, error)
+	GetNodes() ([]Node, error)
+	GetCloudConfig() (*CloudConfig, error)
+	GetAccessKeyID() string
+	GetSecretAccessKey() string
+	GetDestination() string
+}
+
 // APIError represents an error returned by the Elemental Cloud REST API.
 //
 // See https://<elemental_server>/help/rest_api#rest_basics_errors_and_warnings
@@ -44,6 +58,24 @@ type APIError struct {
 func (apiErr *APIError) Error() string {
 	data, _ := json.Marshal(apiErr)
 	return fmt.Sprintf("Error returned by the Elemental Cloud REST Interface: %s", data)
+}
+
+// GetAccessKeyID returns the value for the AWS access key ID set for this
+// client
+func (c *Client) GetAccessKeyID() string {
+	return c.AccessKeyID
+}
+
+// GetSecretAccessKey returns the value for the AWS secret access key set for
+// this client
+func (c *Client) GetSecretAccessKey() string {
+	return c.SecretAccessKey
+}
+
+// GetDestination returns the value of the S3 bucket target destination for
+// the output for transcoding jobs.
+func (c *Client) GetDestination() string {
+	return c.Destination
 }
 
 // NewClient creates a instance of the client type.

--- a/elementalconductor/client_test.go
+++ b/elementalconductor/client_test.go
@@ -119,3 +119,11 @@ func (s *S) TestInvalidAuth(c *check.C) {
 		Errors: errorResponse,
 	})
 }
+
+func (s *S) TestClientInterface(c *check.C) {
+	var i interface{} = &Client{}
+	_, ok := i.(ClientInterface)
+	if !ok {
+		c.Error("Client struct does not implement ClientInterface")
+	}
+}

--- a/elementalconductor/job.go
+++ b/elementalconductor/job.go
@@ -120,7 +120,7 @@ type Job struct {
 	Href            string           `xml:"href,attr,omitempty"`
 	Input           Input            `xml:"input,omitempty"`
 	Priority        int              `xml:"priority,omitempty"`
-	OutputGroup     OutputGroup      `xml:"output_group,omitempty"`
+	OutputGroup     []OutputGroup    `xml:"output_group,omitempty"`
 	StreamAssembly  []StreamAssembly `xml:"stream_assembly,omitempty"`
 	Status          string           `xml:"status,omitempty"`
 	Submitted       DateTime         `xml:"submitted,omitempty"`

--- a/elementalconductor/job_test.go
+++ b/elementalconductor/job_test.go
@@ -96,29 +96,31 @@ func (s *S) TestCreateJob(c *check.C) {
 			},
 		},
 		Priority: 50,
-		OutputGroup: OutputGroup{
-			Order: 1,
-			FileGroupSettings: &FileGroupSettings{
-				Destination: &Location{
-					URI:      "http://destination/video.mp4",
-					Username: "user",
-					Password: "pass123",
+		OutputGroup: []OutputGroup{
+			{
+				Order: 1,
+				FileGroupSettings: &FileGroupSettings{
+					Destination: &Location{
+						URI:      "http://destination/video.mp4",
+						Username: "user",
+						Password: "pass123",
+					},
 				},
-			},
-			AppleLiveGroupSettings: &AppleLiveGroupSettings{
-				Destination: &Location{
-					URI:      "http://destination/video.mp4",
-					Username: "user",
-					Password: "pass123",
+				AppleLiveGroupSettings: &AppleLiveGroupSettings{
+					Destination: &Location{
+						URI:      "http://destination/video.mp4",
+						Username: "user",
+						Password: "pass123",
+					},
 				},
-			},
-			Type: AppleLiveOutputGroupType,
-			Output: []Output{
-				{
-					StreamAssemblyName: "stream_1",
-					NameModifier:       "_high",
-					Order:              1,
-					Extension:          ".mp4",
+				Type: AppleLiveOutputGroupType,
+				Output: []Output{
+					{
+						StreamAssemblyName: "stream_1",
+						NameModifier:       "_high",
+						Order:              1,
+						Extension:          ".mp4",
+					},
 				},
 			},
 		},
@@ -184,22 +186,24 @@ func (s *S) TestGetJob(c *check.C) {
 			},
 		},
 		Priority: 50,
-		OutputGroup: OutputGroup{
-			Order: 1,
-			FileGroupSettings: &FileGroupSettings{
-				Destination: &Location{
-					URI:      "http://destination/video.mp4",
-					Username: "user",
-					Password: "pass123",
+		OutputGroup: []OutputGroup{
+			{
+				Order: 1,
+				FileGroupSettings: &FileGroupSettings{
+					Destination: &Location{
+						URI:      "http://destination/video.mp4",
+						Username: "user",
+						Password: "pass123",
+					},
 				},
-			},
-			Type: FileOutputGroupType,
-			Output: []Output{
-				{
-					StreamAssemblyName: "stream_1",
-					NameModifier:       "_high",
-					Order:              1,
-					Extension:          ".mp4",
+				Type: FileOutputGroupType,
+				Output: []Output{
+					{
+						StreamAssemblyName: "stream_1",
+						NameModifier:       "_high",
+						Order:              1,
+						Extension:          ".mp4",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Changes to Elemental Conductor client:
* Allow for multiple output groups. This is useful when working with adaptive streaming and non-adaptive streaming presets on the same job.
* Export client interface so it's easier to mock it.