### PR TITLE
elementalconductor: add duration to job

### DIFF
--- a/elementalconductor/job.go
+++ b/elementalconductor/job.go
@@ -132,6 +132,7 @@ type Job struct {
 	XMLName         xml.Name         `xml:"job"`
 	Href            string           `xml:"href,attr,omitempty"`
 	Input           Input            `xml:"input,omitempty"`
+	ContentDuration ContentDuration  `xml:"content_duration,omitempty"`
 	Priority        int              `xml:"priority,omitempty"`
 	OutputGroup     []OutputGroup    `xml:"output_group,omitempty"`
 	StreamAssembly  []StreamAssembly `xml:"stream_assembly,omitempty"`
@@ -154,6 +155,12 @@ type JobError struct {
 // Input represents the spec for the job's input
 type Input struct {
 	FileInput Location `xml:"file_input,omitempty"`
+}
+
+// ContentDuration contains information about the content of the media in the
+// job.
+type ContentDuration struct {
+	InputDuration int `xml:"input_duration"`
 }
 
 // Location defines where a file is or needs to be.

--- a/elementalconductor/job_test.go
+++ b/elementalconductor/job_test.go
@@ -148,6 +148,14 @@ func (s *S) TestGetJob(c *check.C) {
             <password>pass123</password>
         </file_input>
     </input>
+    <content_duration>
+        <input_duration>716</input_duration>
+        <clipped_input_duration>716</clipped_input_duration>
+        <stream_count>1</stream_count>
+        <total_stream_duration>716</total_stream_duration>
+        <package_count>1</package_count>
+        <total_package_duration>716</total_package_duration>
+    </content_duration>
     <priority>50</priority>
     <output_group>
         <order>1</order>
@@ -184,6 +192,9 @@ func (s *S) TestGetJob(c *check.C) {
 				Username: "user",
 				Password: "pass123",
 			},
+		},
+		ContentDuration: ContentDuration{
+			InputDuration: 716,
 		},
 		Priority: 50,
 		OutputGroup: []OutputGroup{


### PR DESCRIPTION
The information is available in the XML response, we were just ignoring
it.