### PR TITLE
provider/elementalconductor: use string for dimensions in video desc

### DIFF
--- a/elementalconductor/client.go
+++ b/elementalconductor/client.go
@@ -114,7 +114,7 @@ func (c *Client) do(method string, path string, body interface{}, out interface{
 			Errors: string(respData),
 		}
 	}
-	if (out != nil) && (string(respData) != " ") {
+	if out != nil && len(respData) > 1 {
 		return xml.Unmarshal(respData, out)
 	}
 	return nil

--- a/elementalconductor/job.go
+++ b/elementalconductor/job.go
@@ -274,6 +274,21 @@ type StreamAssembly struct {
 type StreamVideoDescription struct {
 	Codec       string `xml:"codec"`
 	EncoderType string `xml:"encoder_type"`
-	Height      int64  `xml:"height"`
-	Width       int64  `xml:"width"`
+	Height      string `xml:"height"`
+	Width       string `xml:"width"`
+}
+
+// GetWidth returns the underlying width parsed as an int64.
+func (s *StreamVideoDescription) GetWidth() int64 {
+	return s.getNumber(s.Width)
+}
+
+// GetHeight returns the underlying height parsed as an int64.
+func (s *StreamVideoDescription) GetHeight() int64 {
+	return s.getNumber(s.Height)
+}
+
+func (s *StreamVideoDescription) getNumber(input string) int64 {
+	v, _ := strconv.ParseInt(input, 10, 64)
+	return v
 }

--- a/elementalconductor/job_test.go
+++ b/elementalconductor/job_test.go
@@ -229,7 +229,7 @@ func (s *S) TestGetJob(c *check.C) {
             <stretch_to_output>false</stretch_to_output>
             <timecode_passthrough>false</timecode_passthrough>
             <vbi_passthrough>false</vbi_passthrough>
-            <width>1920</width>
+            <width nil="true"/>
             <gpu>0</gpu>
             <selected_gpu nil="true"/>
             <codec>h.264</codec>
@@ -294,8 +294,8 @@ func (s *S) TestGetJob(c *check.C) {
 				VideoDescription: &StreamVideoDescription{
 					Codec:       "h.264",
 					EncoderType: "gpu",
-					Width:       1920,
-					Height:      1080,
+					Width:       "",
+					Height:      "1080",
 				},
 			},
 		},
@@ -475,5 +475,37 @@ func (s *S) TestVideoInfoDimensions(c *check.C) {
 		if height != t.expectedHeight {
 			c.Errorf("width=%s height=%s\nwant height=%d\ngot  height=%d", t.inputWidth, t.inputHeight, t.expectedHeight, height)
 		}
+	}
+}
+
+func (s *S) TestVideoDescriptionWidth(c *check.C) {
+	var tests = []struct {
+		input  string
+		output int64
+	}{
+		{"1920", 1920},
+		{"", 0},
+		{"whatever", 0},
+	}
+	for _, t := range tests {
+		desc := StreamVideoDescription{Width: t.input}
+		got := desc.GetWidth()
+		c.Check(got, check.Equals, t.output)
+	}
+}
+
+func (s *S) TestVideoDescriptionHeight(c *check.C) {
+	var tests = []struct {
+		input  string
+		output int64
+	}{
+		{"1080", 1080},
+		{"", 0},
+		{"whatever", 0},
+	}
+	for _, t := range tests {
+		desc := StreamVideoDescription{Height: t.input}
+		got := desc.GetHeight()
+		c.Check(got, check.Equals, t.output)
 	}
 }


### PR DESCRIPTION
Different from what I thought, when it's undefined, it's not 0, but something
like ``<width nil="true"/>`` and/or ``<height nil="true"/>``.