### PR TITLE
travis: bump go to 1.7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ install:
 script:
   - make test
 go:
-  - 1.7.1
+  - 1.7.3
   - tip


### PR DESCRIPTION
This PR updates go to [version 1.7.3](https://github.com/golang/go/releases/tag/go1.7.3) on travis. 